### PR TITLE
Fix random seed use in CameraController

### DIFF
--- a/Assets/Scripts/Dungeon/CameraController.cs
+++ b/Assets/Scripts/Dungeon/CameraController.cs
@@ -23,6 +23,12 @@ public class CameraController : SingletonMonoBehaviour<CameraController>
     private const string NextFloorScenePrefix = "Scenes/Dungeons/TohoGakuenOldBuilding/";
     private const string NextFloorSceneSuffix = "Floor";
 
+    protected override void Awake()
+    {
+        base.Awake();
+        UnityEngine.Random.InitState(Environment.TickCount);
+    }
+
     void Update()
     {
         if (Input.GetKeyDown(KeyCode.W))
@@ -136,7 +142,6 @@ public class CameraController : SingletonMonoBehaviour<CameraController>
 
     public void Encount()
     {
-        UnityEngine.Random.InitState(DateTime.Now.Millisecond);
         if (
             StepsAfterEncount >= MinStepsAfterEncount
             && UnityEngine.Random.value < Dungeon.EncountRate


### PR DESCRIPTION
## Summary
- seed UnityEngine.Random in `CameraController.Awake`
- stop reseeding during every encounter check

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68501821654c832ba20e72eb4dbe965f