### PR TITLE
Fix experience handling and dictionary deserialization

### DIFF
--- a/Assets/Scripts/Characters/Player.cs
+++ b/Assets/Scripts/Characters/Player.cs
@@ -19,7 +19,7 @@ public class Player : Character, ISpShowable
         set
         {
             _exp = value;
-            if (_exp >= ExpList[Level - 1])
+            if (Level < ExpList.Length && _exp >= ExpList[Level - 1])
             {
                 LevelUp();
             }
@@ -218,7 +218,9 @@ public class Player : Character, ISpShowable
 
     public void ShowResult()
     {
-        int nextExp = ExpList[Level - 1] - Exp;
+        int nextExp = Level < ExpList.Length
+            ? ExpList[Level - 1] - Exp
+            : 0;
         BattleResult.Instance.Show(nextExp);
     }
 

--- a/Assets/Scripts/Dictionary/SerializableDictionary.cs
+++ b/Assets/Scripts/Dictionary/SerializableDictionary.cs
@@ -24,7 +24,7 @@ public class SerializableDictionary<TKey, TValue> :
         }
     }
 
-    [SerializeField] private List<Pair> _list = null;
+    [SerializeField] private List<Pair> _list = new List<Pair>();
 
     /// <summary>
     /// OnAfterDeserialize
@@ -32,6 +32,11 @@ public class SerializableDictionary<TKey, TValue> :
     void ISerializationCallbackReceiver.OnAfterDeserialize()
     {
         Clear();
+        if (_list == null)
+        {
+            return;
+        }
+
         foreach (var pair in _list)
         {
             if (ContainsKey(pair.Key))


### PR DESCRIPTION
## Summary
- avoid repeated level up attempts when reaching max level
- show zero required EXP at max level
- make `SerializableDictionary` safe when list is null

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68539194ed58832b8fb7c28a26cf6471